### PR TITLE
Do not systematically ask for admin privileges to run UE Explorer

### DIFF
--- a/UE Explorer/app.manifest
+++ b/UE Explorer/app.manifest
@@ -7,8 +7,7 @@
     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
         <security>
             <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
-                <!--<requestedExecutionLevel level="asInvoker" uiAccess="false" />-->
-                <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+                <requestedExecutionLevel level="asInvoker" uiAccess="false" />
             </requestedPrivileges>
             <!--<applicationRequestMinimum>
                 <defaultAssemblyRequest permissionSetReference="Custom" />


### PR DESCRIPTION
Asking for administrator access at all times is not necessary as far as I can see, and looks a bit fishy. The editor should not run with high privileges when it doesn't need to, because it could otherwise become an attack vector. It also makes it unusable on systems configured to run without administrator privileges.

Looking at the commit I do not understand why this change was made in the first place. If the goal is to access files that could be potentially write-locked, directly from Program Files or wherever else games are installed, then could I suggest instead elevating the program whenever needed rather than running it elevated at all times?