### PR TITLE
Fix for the Classes tab pulling from Import table

### DIFF
--- a/UE Explorer/UI/Tabs/UC_PackageExplorer.cs
+++ b/UE Explorer/UI/Tabs/UC_PackageExplorer.cs
@@ -698,7 +698,7 @@ namespace UEExplorer.UI.Tabs
 
         private void _OnNotifyObjectAdded( object sender, ObjectEventArgs e )
         {
-            if( e.ObjectRef.Table.ClassIndex == 0 && e.ObjectRef.Name.ToLower() != "none" )
+            if( e.ObjectRef.ExportTable != null && e.ObjectRef.Table.ClassIndex == 0 && e.ObjectRef.Name.ToLower() != "none" )
             {
                 _ClassesList.Add( (UClass)e.ObjectRef );
             }


### PR DESCRIPTION
The if statement in `_OnNotifyObjectAdded` currently doesn't check if the object is from the Export table before checking if it's a class. Thus it can show classes from the Import table if the first entry in the Name table happens to be 'Class'.