### PR TITLE
Fix menu item shortcuts

### DIFF
--- a/UE Explorer/UI/Tabs/TabsCollection.cs
+++ b/UE Explorer/UI/Tabs/TabsCollection.cs
@@ -11,7 +11,7 @@ namespace UEExplorer.UI
     {
         void TabSave();
         void TabFind();
-        void TabSelected();
+        void TabSelected(bool isSelected);
     }
 
     // TODO: Deprecate
@@ -88,8 +88,12 @@ namespace UEExplorer.UI
             if (e.ChangeType != TabStripItemChangeTypes.SelectionChanged)
                 return;
 
-            if (e.Item.Controls.Count > 0 && e.Item.Controls[0] is ITabComponent tabComponent)
-                tabComponent.TabSelected();
+            foreach (TabStripItem tabStripItem in _TabStrip.Items)
+            {
+                if (tabStripItem.Controls.Count > 0 &&
+                    tabStripItem.Controls[0] is ITabComponent tabComponent)
+                    tabComponent.TabSelected(tabStripItem == e.Item);
+            }
         }
     }
 }

--- a/UE Explorer/UI/Tabs/TabsCollection.cs
+++ b/UE Explorer/UI/Tabs/TabsCollection.cs
@@ -11,6 +11,7 @@ namespace UEExplorer.UI
     {
         void TabSave();
         void TabFind();
+        void TabSelected();
     }
 
     // TODO: Deprecate
@@ -21,12 +22,16 @@ namespace UEExplorer.UI
         public TabsCollection(TabStrip tabStrip)
         {
             _TabStrip = tabStrip;
+
+            _TabStrip.TabStripItemSelectionChanged += TabStripItemSelectionChanged;
         }
 
         public ITabComponent SelectedComponent => (ITabComponent)_TabStrip.SelectedItem?.Controls[0];
 
         public void Dispose()
         {
+            _TabStrip.TabStripItemSelectionChanged -= TabStripItemSelectionChanged;
+
             _TabStrip = null;
         }
 
@@ -65,15 +70,26 @@ namespace UEExplorer.UI
                     ? component.GetType().Name
                     : uniqueName,
             };
-            _TabStrip.AddTab(tabItem, true);
+            _TabStrip.AddTab(tabItem, false);
 
             // We have to add this last for proper layout rendering.
             tabItem.Controls.Add(component);
+
+            _TabStrip.SelectedItem = tabItem;
         }
 
         public void CloseTab(TabStripItem itemToRemove)
         {
             _TabStrip.RemoveTab(itemToRemove);
+        }
+
+        private void TabStripItemSelectionChanged(TabStripItemChangedEventArgs e)
+        {
+            if (e.ChangeType != TabStripItemChangeTypes.SelectionChanged)
+                return;
+
+            if (e.Item.Controls.Count > 0 && e.Item.Controls[0] is ITabComponent tabComponent)
+                tabComponent.TabSelected();
         }
     }
 }

--- a/UE Explorer/UI/Tabs/UC_PackageExplorer.cs
+++ b/UE Explorer/UI/Tabs/UC_PackageExplorer.cs
@@ -43,12 +43,12 @@ namespace UEExplorer.UI.Tabs
         {
             InitializeComponent();
 
-            var ComponentResourceManager = new ComponentResourceManager(typeof(UC_PackageExplorer));
+            var resources = new ComponentResourceManager(typeof(UC_PackageExplorer));
 
-            _FindNextShortcutKeys = (Keys)ComponentResourceManager.GetObject("findNextToolStripMenuItem.ShortcutKeys");
-            _ViewBufferShortcutKeys = (Keys)ComponentResourceManager.GetObject("viewBufferToolStripMenuItem.ShortcutKeys");
-            _FindInClassesShortcutKeys = (Keys)ComponentResourceManager.GetObject("findInClassesToolStripMenuItem.ShortcutKeys");
-            _FindInDocumentShortcutKeys = (Keys)ComponentResourceManager.GetObject("findInDocumentToolStripMenuItem.ShortcutKeys");
+            _FindNextShortcutKeys = (Keys)resources.GetObject("findNextToolStripMenuItem.ShortcutKeys");
+            _ViewBufferShortcutKeys = (Keys)resources.GetObject("viewBufferToolStripMenuItem.ShortcutKeys");
+            _FindInClassesShortcutKeys = (Keys)resources.GetObject("findInClassesToolStripMenuItem.ShortcutKeys");
+            _FindInDocumentShortcutKeys = (Keys)resources.GetObject("findInDocumentToolStripMenuItem.ShortcutKeys");
         }
 
         private void UC_PackageExplorer_Load(object sender, EventArgs e)

--- a/UE Explorer/UI/Tabs/UC_PackageExplorer.cs
+++ b/UE Explorer/UI/Tabs/UC_PackageExplorer.cs
@@ -1646,12 +1646,12 @@ namespace UEExplorer.UI.Tabs
             }
         }
 
-        public override void TabSelected()
+        public override void TabSelected(bool isSelected)
         {
-            findNextToolStripMenuItem.ShortcutKeys = _FindNextShortcutKeys;
-            viewBufferToolStripMenuItem.ShortcutKeys = _ViewBufferShortcutKeys;
-            findInClassesToolStripMenuItem.ShortcutKeys = _FindInClassesShortcutKeys;
-            findInDocumentToolStripMenuItem.ShortcutKeys = _FindInDocumentShortcutKeys;
+            findNextToolStripMenuItem.ShortcutKeys = isSelected ? _FindNextShortcutKeys : Keys.None;
+            viewBufferToolStripMenuItem.ShortcutKeys = isSelected ? _ViewBufferShortcutKeys : Keys.None;
+            findInClassesToolStripMenuItem.ShortcutKeys = isSelected ? _FindInClassesShortcutKeys : Keys.None;
+            findInDocumentToolStripMenuItem.ShortcutKeys = isSelected ? _FindInDocumentShortcutKeys : Keys.None;
         }
 
         private struct BufferData

--- a/UE Explorer/UI/Tabs/UC_PackageExplorer.cs
+++ b/UE Explorer/UI/Tabs/UC_PackageExplorer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
@@ -33,9 +34,21 @@ namespace UEExplorer.UI.Tabs
         /// </summary>
         private UnrealPackage _UnrealPackage;
 
+        private Keys _FindNextShortcutKeys;
+        private Keys _ViewBufferShortcutKeys;
+        private Keys _FindInClassesShortcutKeys;
+        private Keys _FindInDocumentShortcutKeys;
+
         public UC_PackageExplorer()
         {
             InitializeComponent();
+
+            var ComponentResourceManager = new ComponentResourceManager(typeof(UC_PackageExplorer));
+
+            _FindNextShortcutKeys = (Keys)ComponentResourceManager.GetObject("findNextToolStripMenuItem.ShortcutKeys");
+            _ViewBufferShortcutKeys = (Keys)ComponentResourceManager.GetObject("viewBufferToolStripMenuItem.ShortcutKeys");
+            _FindInClassesShortcutKeys = (Keys)ComponentResourceManager.GetObject("findInClassesToolStripMenuItem.ShortcutKeys");
+            _FindInDocumentShortcutKeys = (Keys)ComponentResourceManager.GetObject("findInDocumentToolStripMenuItem.ShortcutKeys");
         }
 
         private void UC_PackageExplorer_Load(object sender, EventArgs e)
@@ -1631,6 +1644,14 @@ namespace UEExplorer.UI.Tabs
             {
                 findDialog.ShowDialog();
             }
+        }
+
+        public override void TabSelected()
+        {
+            findNextToolStripMenuItem.ShortcutKeys = _FindNextShortcutKeys;
+            viewBufferToolStripMenuItem.ShortcutKeys = _ViewBufferShortcutKeys;
+            findInClassesToolStripMenuItem.ShortcutKeys = _FindInClassesShortcutKeys;
+            findInDocumentToolStripMenuItem.ShortcutKeys = _FindInDocumentShortcutKeys;
         }
 
         private struct BufferData

--- a/UE Explorer/UI/Tabs/UserControl_Tab.cs
+++ b/UE Explorer/UI/Tabs/UserControl_Tab.cs
@@ -14,5 +14,9 @@ namespace UEExplorer.UI.Tabs
         public virtual void TabFind()
         {
         }
+
+        public virtual void TabSelected()
+        {
+        }
     }
 }

--- a/UE Explorer/UI/Tabs/UserControl_Tab.cs
+++ b/UE Explorer/UI/Tabs/UserControl_Tab.cs
@@ -15,7 +15,7 @@ namespace UEExplorer.UI.Tabs
         {
         }
 
-        public virtual void TabSelected()
+        public virtual void TabSelected(bool isSelected)
         {
         }
     }


### PR DESCRIPTION
This PR detects when a tab is selected and sets the shortcuts again so the `System.Windows.Forms.ToolStripManager` correctly handles shortcuts on the selected tab.

Fixes #38